### PR TITLE
Added config for the IU BigRed200 machine

### DIFF
--- a/mpi4py.cfg.in
+++ b/mpi4py.cfg.in
@@ -41,3 +41,14 @@ runtime_library_dirs = @CMAKE_INSTALL_PREFIX@/lib
 extra_compile_args   = @CMAKE_C_FLAGS@ @MPI4PY_CFLAGS@
 extra_link_args      = @MPI4PY_LDFLAGS@
 extra_objects        =
+
+[bigred200]
+mpicc                = @CMAKE_C_COMPILER@
+mpicxx               = @CMAKE_CXX_COMPILER@
+include_dirs         = @CMAKE_INSTALL_PREFIX@/include
+libraries            =
+library_dirs         =
+runtime_library_dirs = @CMAKE_INSTALL_PREFIX@/lib
+extra_compile_args   = @CMAKE_C_FLAGS@ @MPI4PY_CFLAGS@
+extra_link_args      = @MPI4PY_LDFLAGS@
+extra_objects        =


### PR DESCRIPTION
Big Red 200 is a Cray Shasta, FYI.

I got mpi4py to build on this machine by modifying the `mpi4py.cfg.in` file as in this PR and by setting the environment variable `NERSC_HOST=bigred200` prior to running cmake, which seems like a bit of a kludge.  Maybe a better way to handle this already exists?